### PR TITLE
fix: shutdown Intercom session on logout

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -25,6 +25,11 @@ export class AppComponent implements OnInit, AfterViewInit {
   }
 
   ngOnInit() {
+    // On fresh page load (e.g. after logout redirect), Intercom may retain
+    // its previous authenticated session in cookies/localStorage.  Shut it
+    // down before booting anonymous so the old session is cleared.
+    this.intercomService.shutdown();
+
     // Boot Intercom in anonymous mode so banners/popups show for all visitors
     this.bootIntercomAnonymous();
 

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -247,6 +247,11 @@ export class AuthService {
       returnTo: `${window.location.origin}${searchPart}${fragmentPart}`,
     };
 
+    // Clear local user state before Auth0 redirect so Intercom (and any
+    // other subscriber) can react while the page is still alive.
+    this.userProfileSubject$.next(null);
+    this.loggedIn = false;
+
     this.auth0Client$.subscribe((client: Auth0Client) =>
       client.logout(request)
     );


### PR DESCRIPTION
## Summary

- **Clear `userProfileSubject$` in `logout()` before the Auth0 redirect** so AppComponent's subscription can trigger `intercomService.shutdown()` while the page is still alive
- **Call `intercomService.shutdown()` on `AppComponent` init** to clear any stale Intercom session from a previous page load (e.g. after the logout redirect)

### Root cause

`AuthService.logout()` called `client.logout()` (which triggers a full-page redirect to Auth0) without first emitting `null` to `userProfileSubject$`. The AppComponent subscription watching `userProfile$` never saw a falsy value, so `shutdown()` was never called. Intercom's own cookies/localStorage kept the authenticated session alive across the redirect.

## Test plan

- [ ] Log in, verify Intercom shows authenticated widget
- [ ] Log out, verify Intercom widget disappears (no stale session)
- [ ] Refresh page after logout, verify only anonymous Intercom loads
- [ ] Log in again, verify Intercom boots with new identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)