### PR TITLE
feat: open Intercom on Support link click instead of Jira

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -4,7 +4,6 @@
   -->
 
 <lfx-header-v2 product="LF CLA" id="lfx-header" userefreshtoken="true" (toggled)="onToggled()"
-supportlink="https://jira.linuxfoundation.org/plugins/servlet/theme/portal/4/create/143"
 docslink="https://docs.linuxfoundation.org/lfx/easycla/v2-current"
 faqlink="https://docs.linuxfoundation.org/lfx/easycla/v2-current/getting-started/easycla-faqs">
 </lfx-header-v2>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -75,6 +75,7 @@ export class AppComponent implements OnInit, AfterViewInit {
     this.lfxHeaderService.setUserInLFxHeader();
     this.lfxHeaderService.setCallBackUrl();
     this.lfxHeaderService.handleLogout();
+    this.lfxHeaderService.setSupportClickHandler();
   }
 
   onToggled() {

--- a/src/app/config/app-settings.ts
+++ b/src/app/config/app-settings.ts
@@ -17,5 +17,4 @@ export class AppSettings {
     public static CORPORATE_CONSOLE_LINK_V2 = 'corporate-v2-base';
     public static REQUEST_ACCESS_LINK = 'https://docs.google.com/forms/d/e/1FAIpQLSdnTk_9xjk7YoiX_FcPEqsFytsLMcT8OzYUbK6TsYopR1XhdA/viewform';
     public static CONTRIBUTORS_LEARN_MORE = 'https://docs.linuxfoundation.org/lfx/easycla/v2-current/contributors';
-    public static TICKET_URL = 'https://jira.linuxfoundation.org/servicedesk/customer/portal/4/create/143';
 }

--- a/src/app/core/services/lfx-header.service.ts
+++ b/src/app/core/services/lfx-header.service.ts
@@ -46,4 +46,16 @@ export class LfxHeaderService {
       lfHeaderEl.authuser = data;
     });
   }
+
+  setSupportClickHandler(): void {
+    const lfHeaderEl: any = document.getElementById('lfx-header');
+    if (!lfHeaderEl) {
+      return;
+    }
+    lfHeaderEl.onsupportclick = () => {
+      if (window.Intercom) {
+        window.Intercom('show');
+      }
+    };
+  }
 }


### PR DESCRIPTION
## Summary

- Removes the static `supportlink` Jira URL from the `<lfx-header-v2>` template
- Adds `setSupportClickHandler()` to `LfxHeaderService` that sets `onsupportclick` to open the Intercom chat widget via `window.Intercom('show')`
- Calls `setSupportClickHandler()` from `ngAfterViewInit()` in `AppComponent`

This matches the pattern already used in LFX Mentorship and Crowdfunding. The Intercom service was already fully wired up (anonymous boot, identified boot, shutdown on logout).

## Test plan

- [ ] Click "Support" in the LFX header — Intercom chat widget opens
- [ ] Verify no Jira redirect occurs
- [ ] Verify Intercom opens for both anonymous and authenticated users

🤖 Generated with [Claude Code](https://claude.com/claude-code)